### PR TITLE
Add tier upgrade feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# gptdeneme
+# Energy Game
+
+A minimal incremental game built for Codex demonstration.
+
+## Running
+
+From the project directory, launch a simple web server:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000` in your browser.
+
+Each click on **Gain Energy** adds energy. Every 10 items convert to the next tier. Conversions play a short upgrade sound and briefly highlight the tier.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Energy Game</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="game">
+        <button id="energy-button">Gain Energy</button>
+        <div id="tiers">
+            <div class="tier" id="energy-tier">
+                <h3>Energy: <span id="energy-count">0</span></h3>
+                <div class="progress"><div class="bar" id="energy-progress"></div></div>
+            </div>
+            <div class="tier" id="electron-tier">
+                <h3>Electrons: <span id="electron-count">0</span></h3>
+                <div class="progress"><div class="bar" id="electron-progress"></div></div>
+            </div>
+            <div class="tier" id="atom-tier">
+                <h3>Atoms: <span id="atom-count">0</span></h3>
+                <div class="progress"><div class="bar" id="atom-progress"></div></div>
+            </div>
+            <div class="tier" id="cell-tier">
+                <h3>Cells: <span id="cell-count">0</span></h3>
+                <div class="progress"><div class="bar" id="cell-progress"></div></div>
+            </div>
+            <div class="tier" id="planet-tier">
+                <h3>Planets: <span id="planet-count">0</span></h3>
+                <div class="progress"><div class="bar" id="planet-progress"></div></div>
+            </div>
+            <div class="tier" id="galaxy-tier">
+                <h3>Galaxies: <span id="galaxy-count">0</span></h3>
+            </div>
+        </div>
+    </div>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,109 @@
+const state = {
+    energy: 0,
+    electron: 0,
+    atom: 0,
+    cell: 0,
+    planet: 0,
+    galaxy: 0
+};
+
+function loadState() {
+    const saved = localStorage.getItem('energyGame');
+    if (saved) {
+        Object.assign(state, JSON.parse(saved));
+    }
+}
+
+function saveState() {
+    localStorage.setItem('energyGame', JSON.stringify(state));
+}
+
+loadState();
+setInterval(saveState, 5000);
+
+const energyBtn = document.getElementById('energy-button');
+energyBtn.addEventListener('click', () => {
+    state.energy += 1;
+    playClick();
+});
+
+const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+function playClick() {
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    gain.gain.value = 0.1;
+    osc.frequency.value = 300;
+    osc.type = 'square';
+    osc.connect(gain).connect(audioCtx.destination);
+    osc.start();
+    osc.stop(audioCtx.currentTime + 0.05);
+}
+
+function playUpgrade() {
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    gain.gain.value = 0.15;
+    osc.frequency.value = 600;
+    osc.type = 'sine';
+    osc.connect(gain).connect(audioCtx.destination);
+    osc.start();
+    osc.stop(audioCtx.currentTime + 0.1);
+}
+
+function flashTier(id) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.classList.add('flash');
+    setTimeout(() => el.classList.remove('flash'), 400);
+}
+
+function updateDOM() {
+    document.getElementById('energy-count').textContent = Math.floor(state.energy);
+    document.getElementById('electron-count').textContent = Math.floor(state.electron);
+    document.getElementById('atom-count').textContent = Math.floor(state.atom);
+    document.getElementById('cell-count').textContent = Math.floor(state.cell);
+    document.getElementById('planet-count').textContent = Math.floor(state.planet);
+    document.getElementById('galaxy-count').textContent = Math.floor(state.galaxy);
+
+    document.getElementById('energy-progress').style.width = (state.energy % 10) * 10 + '%';
+    document.getElementById('electron-progress').style.width = (state.electron % 10) * 10 + '%';
+    document.getElementById('atom-progress').style.width = (state.atom % 10) * 10 + '%';
+    document.getElementById('cell-progress').style.width = (state.cell % 10) * 10 + '%';
+    document.getElementById('planet-progress').style.width = (state.planet % 10) * 10 + '%';
+}
+
+function convert(base, next, tierId) {
+    let upgraded = false;
+    while (state[base] >= 10) {
+        state[base] -= 10;
+        state[next] += 1;
+        upgraded = true;
+    }
+    if (upgraded) {
+        playUpgrade();
+        flashTier(tierId);
+    }
+}
+
+let last = performance.now();
+function loop(now) {
+    const dt = (now - last) / 1000;
+    last = now;
+
+    // passive generation
+    state.energy += state.electron * dt;
+    state.electron += state.atom * dt;
+    state.atom += state.cell * dt;
+    state.cell += state.planet * dt;
+    state.planet += state.galaxy * dt;
+
+    convert('energy', 'electron', 'electron-tier');
+    convert('electron', 'atom', 'atom-tier');
+    convert('atom', 'cell', 'cell-tier');
+    convert('cell', 'planet', 'planet-tier');
+    convert('planet', 'galaxy', 'galaxy-tier');
+
+    updateDOM();
+    requestAnimationFrame(loop);
+}
+requestAnimationFrame(loop);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,52 @@
+body {
+    background: #121212;
+    color: #eee;
+    font-family: Arial, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+#game {
+    text-align: center;
+}
+#energy-button {
+    width: 150px;
+    height: 150px;
+    border-radius: 50%;
+    border: none;
+    background: #444;
+    color: #fff;
+    font-size: 18px;
+    cursor: pointer;
+    animation: pulse 1.5s infinite;
+}
+.progress {
+    background: #333;
+    width: 200px;
+    height: 10px;
+    margin: 4px auto;
+}
+.bar {
+    background: #0f0;
+    height: 100%;
+    width: 0%;
+}
+.tier {
+    margin: 10px 0;
+}
+
+.tier.flash {
+    animation: flash 0.4s;
+}
+
+@keyframes flash {
+    from { background: #555; }
+    to { background: transparent; }
+}
+@keyframes pulse {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.1); }
+    100% { transform: scale(1); }
+}


### PR DESCRIPTION
## Summary
- highlight tiers with a flash animation when they level up
- play a short upgrade sound on tier conversion
- document run instructions and new feedback in README

## Testing
- `node -v`
- `python3 -m http.server 8000` and fetched `index.html`

------
https://chatgpt.com/codex/tasks/task_e_6841be0cc5a48325b3dc4f3f566e77af